### PR TITLE
Add extractSource parameter

### DIFF
--- a/core/components/simplesearch/docs/changelog.txt
+++ b/core/components/simplesearch/docs/changelog.txt
@@ -1,5 +1,9 @@
 Changelog for SimpleSearch.
 
+SimpleSearch next
+========================================================================
+- Added extractSource parameter - names the field for the extract, or a snippet to run (which is passed the resource array as properties)
+
 SimpleSearch 1.8.1
 ========================================================================
 - Added snippet for definition of ElasticSearch index (duplicate it and remove the _default from name to prevent recreating after update)

--- a/core/components/simplesearch/elements/snippets/simplesearch.snippet.php
+++ b/core/components/simplesearch/elements/snippets/simplesearch.snippet.php
@@ -58,6 +58,7 @@ if (!$searchString) {
 $tpl = $modx->getOption('tpl',$scriptProperties,'SearchResult');
 $containerTpl = $modx->getOption('containerTpl',$scriptProperties,'SearchResults');
 $showExtract = $modx->getOption('showExtract',$scriptProperties,true);
+$extractSource = $modx->getOption('extractSource',$scriptProperties,'content');
 $extractLength = $modx->getOption('extractLength',$scriptProperties,200);
 $extractEllipsis = $modx->getOption('extractEllipsis',$scriptProperties,'...');
 $highlightResults = $modx->getOption('highlightResults',$scriptProperties,true);
@@ -91,7 +92,12 @@ if (!empty($response['results'])) {
         }
         if ($showExtract) {
             $extract = array_pop($search->searchArray);
-            $extract = $search->createExtract($resourceArray['content'],$extractLength,$extract,$extractEllipsis);
+            if (array_key_exists($extractSource, $resourceArray)) {
+                $text = $resourceArray[$extractSource];
+            } else {
+                $text = $modx->runSnippet($extractSource, $resourceArray);
+            }
+            $extract = $search->createExtract($text,$extractLength,$extract,$extractEllipsis);
             /* cleanup extract */
             $extract = strip_tags(preg_replace("#\<!--(.*?)--\>#si",'',$extract));
             $extract = preg_replace("#\[\[(.*?)\]\]#si",'',$extract);


### PR DESCRIPTION
Allows the user to define where the extract comes from. If the value of this parameter
is a resource field name (including TVs if &includeTVs is set) then that resource
field is used for the extract. Otherwise the parameter is taken as the name of a
Snippet to run. The Snippet is passed the resource array as parameters. If there
is no Snippet by that name, then the extract will be empty.

Solves Issue #7
