### PR TITLE
option to show noResultsTplOnEmptySearchKey or not

### DIFF
--- a/core/components/simplesearch/elements/snippets/simplesearch.snippet.php
+++ b/core/components/simplesearch/elements/snippets/simplesearch.snippet.php
@@ -38,11 +38,13 @@ $search = new SimpleSearch($modx,$scriptProperties);
 $searchIndex = $modx->getOption('searchIndex',$scriptProperties,'search');
 $toPlaceholder = $modx->getOption('toPlaceholder',$scriptProperties,false);
 $noResultsTpl = $modx->getOption('noResultsTpl',$scriptProperties,'SearchNoResults');
+$noResultsTplOnEmptySearchKey = $modx->getOption('noResultsTplOnEmptySearchKey',$scriptProperties,true);
 $debug = (bool)$modx->getOption('debug', $scriptProperties, false);
 
 $debug_output = '';
 /* get search string */
 if (empty($_REQUEST[$searchIndex])) {
+    if (!$noResultsTplOnEmptySearchKey && !$debug) return '';
     $output = $search->getChunk($noResultsTpl,array(
         'query' => '',
     ));
@@ -54,6 +56,7 @@ if (empty($_REQUEST[$searchIndex])) {
 }
 $searchString = $search->parseSearchString($_REQUEST[$searchIndex]);
 if (!$searchString) {
+    if (!$noResultsTplOnEmptySearchKey && !$debug) return '';
     $output = $search->getChunk($noResultsTpl,array(
         'query' => $searchString,
     ));


### PR DESCRIPTION
## What does it do?

Adds a snippet property to show or not show the `noResultsTpl` chunk when the search key is empty or not valid. Defaults to `true` to conserve b/c.
## Why?

On Resources where the search page has both search results and the search form,  then when you load the page the search key is empty. But you still get: `There were no search results for the search "". Please try using more general terms to get more results.`

Which in this case is totally dumb, because you haven't searched for anything. It's a different case than the user searched for something and no results were found, so either a whole other TPL option should be provided (overkill maybe?) or this property should be there so someone can at least escape.
