### PR TITLE
add a check for 'searchable' in plugin

### DIFF
--- a/core/components/simplesearch/elements/plugins/plugin.simplesearchindexer.php
+++ b/core/components/simplesearch/elements/plugins/plugin.simplesearchindexer.php
@@ -71,7 +71,7 @@ switch ($modx->event->name) {
         $action = 'index';
         $resourceArray = $scriptProperties['resource']->toArray();
 
-        if ($resourceArray['published'] == 1 && $resourceArray['deleted'] == 0) {
+        if ($resourceArray['published'] == 1 && $resourceArray['deleted'] == 0 && $resourceArray['searchable'] == 1) {
             $action = 'index';
             foreach ($_POST as $k => $v) {
                 if (substr($k,0,2) == 'tv') {


### PR DESCRIPTION
add a check for 'searchable' in plugin so non-searchable resources get removed from the index if searchability changes after being saved

Fixes a bug where, if a resource were saved with the "Searchable" box checked, then a user unchecked the "searchable" box, the resource was not removed from the index.