### PR TITLE
Fix GPM config file for version 3.0.0-alpha

### DIFF
--- a/_build/gpm.yaml
+++ b/_build/gpm.yaml
@@ -295,6 +295,6 @@ systemSettings:
     value: simpleSearchAutoSuggestions
     area: Autosuggest
 build:
-  - scriptsAfter: [resolve.fixsystemsettings.php]
-  - requires:
-      - modx: '>=3.0.0-alpha'
+  scriptsAfter: [resolve.fixsystemsettings.php]
+  requires:
+      modx: '>=3.0.0-alpha'


### PR DESCRIPTION
It seems that the "build" part in the GPM config file is wrong, so that the _fixsystemsettings_ resolver is not included in the package.

I think this PR fixes the problem (but I'm not that familiar with GPM).
This should also resolve issue #51.