### PR TITLE
Bugfix/issue 36

### DIFF
--- a/_build/gpm.yaml
+++ b/_build/gpm.yaml
@@ -5,7 +5,7 @@ description: >-
   Evolution (minus the ajax). Only searches Resources; does not search dynamic
   content.
 author: modxcms
-version: 3.0.0-alpha
+version: 3.0.0-beta
 chunks:
   - name: SearchForm
     file: searchform.chunk.tpl
@@ -289,12 +289,12 @@ snippets:
         lexicon: simplesearch:properties
 systemSettings:
   - key: driver_class
-    value: \SimpleSearch\Driver\SimpleSearchDriverBasic
+    value: ''
     area: Drivers
   - key: autosuggest_tv
     value: simpleSearchAutoSuggestions
     area: Autosuggest
 build:
-  - scriptsAfter: [resolve.fixsystemsettings.php]
-  - requires:
-      - modx: '>=3.0.0-alpha'
+  scriptsAfter: [resolve.fixsystemsettings.php]
+  requires:
+      modx: '>=3.0.0-alpha'

--- a/_build/scripts/resolve.fixsystemsettings.php
+++ b/_build/scripts/resolve.fixsystemsettings.php
@@ -1,25 +1,16 @@
-
-
 <?php
-/**
- * @var \Teleport\Transport\Transport $transport
- * @var array $object
- * @var array $options
- */
 
-switch ($options[xPDOTransport::PACKAGE_ACTION]) {
-    case xPDOTransport::ACTION_UPGRADE:
-        /** @var modX $modx */
-        $modx =& $transport->xpdo;
+use MODX\Revolution\modSystemSetting;
 
-        /** @var \MODX\Revolution\modSystemSetting $ss */
-        $ss = $modx->getObject(\MODX\Revolution\modSystemSetting::class, ['key' => 'simplesearch.driver_class']);
-        if ($ss && $ss->value === 'SimpleSearchDriverBasic') {
-            $ss->set('value', '\SimpleSearch\Driver\SimpleSearchDriverBasic');
-            $ss->save();
-        }
-
-        break;
+/** @var array $options */
+if ($options[xPDOTransport::PACKAGE_ACTION] === xPDOTransport::ACTION_UPGRADE) {
+    /** @var xPDOTransport $transport */
+    /** @var modSystemSetting $setting */
+    $setting = $transport->xpdo->getObject(modSystemSetting::class, ['key' => 'simplesearch.driver_class']);
+    if ($setting && $setting->value === 'SimpleSearchDriverBasic') {
+        $setting->set('value', '');
+        $setting->save();
+    }
 }
 
 return true;

--- a/assets/components/simplesearch/connector.php
+++ b/assets/components/simplesearch/connector.php
@@ -1,20 +1,20 @@
 <?php
 
-require_once dirname(dirname(dirname(__DIR__))) . '/config.core.php';
+/** @var \MODX\Revolution\modX $modx */
+require_once dirname(__DIR__, 3) . '/config.core.php';
 require_once MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 require_once MODX_CONNECTORS_PATH . 'index.php';
 
+use SimpleSearch\Processors\Web\AutoSuggestions;
 use SimpleSearch\SimpleSearch;
 
 $webActions = [
-    'web/autosuggestions'
+    'web/autosuggestions' => AutoSuggestions::class,
 ];
 
-if (!empty($_REQUEST['action']) && in_array($_REQUEST['action'], $webActions)) {
+if (!empty($_REQUEST['action']) && array_key_exists($_REQUEST['action'], $webActions)) {
     define('MODX_REQP', false);
-}
 
-if (in_array($_REQUEST['action'], $webActions, true)) {
     if ($modx->user->hasSessionContext($modx->context->get('key'))) {
         $_SERVER['HTTP_MODAUTH'] = $_SESSION["modx.{$modx->context->get('key')}.user.token"];
     } else {
@@ -23,12 +23,13 @@ if (in_array($_REQUEST['action'], $webActions, true)) {
     }
 
     $_REQUEST['HTTP_MODAUTH'] = $_SERVER['HTTP_MODAUTH'];
+    $_REQUEST['action'] = $webActions[$_REQUEST['action']];
 }
 
 $instance = $modx->services->get('simplesearch');
 if ($instance instanceof SimpleSearch) {
     $modx->request->handleRequest([
         'processors_path' => $instance->config['processors_path'],
-        'location'        => ''
+        'location' => '',
     ]);
 }

--- a/core/components/simplesearch/src/SimpleSearch.php
+++ b/core/components/simplesearch/src/SimpleSearch.php
@@ -453,12 +453,12 @@ class SimpleSearch
     public function addHighlighting(string $string, string $cls = 'simplesearch-highlight', string $tag = 'span'): string
     {
         $searchStrings = explode(' ', $this->searchString);
+        $replacement = '<'.$tag.' class="'.$cls.'">$0</'.$tag.'>';
+        $searchParts = [];
         foreach ($searchStrings as $searchString) {
-            $quoteValue = preg_quote($searchString, '/');
-            $string     = preg_replace('/' . $quoteValue . '/i', '<'.$tag.' class="'.$cls.'">$0</'.$tag.'>', $string);
+            $searchParts[] = '(' . preg_quote($searchString, '/') . ')';
         }
-
-        return $string;
+        return preg_replace('/' . implode('|', $searchParts) . '/i', $replacement, $string);
     }
 
     /**


### PR DESCRIPTION
Fixing an issue #36
The code fix addresses that search terms are highlighted by tag and class.
If search string contains several segments, each segment is enclosed with element to highlight it.
Issue is that if search segment matches any part of highlighting tag, it will be enclosed with highlight tag again.
for example:
Search string is "De las"
The highlighting would work like:
Pass 1: Match "De" in "De las" and replace. The result is "De las"
Pass 2: Match "les" in "<span class='simplesearch-highlight'>De las" and replace. The result is:
<span c<span class='simplesearch-highlight'>las</span>s='simplesearch-highlight'>De</span> las

The fix is to highlight each segment of search string separately and then concatenate all segments back to string.