### PR TITLE
Fix property 'exclude'

### DIFF
--- a/core/components/simplesearch/src/Driver/SimpleSearchDriverBasic.php
+++ b/core/components/simplesearch/src/Driver/SimpleSearchDriverBasic.php
@@ -221,6 +221,10 @@ class SimpleSearchDriverBasic extends SimpleSearchDriver
             $f = $this->modx->getSelectColumns(modResource::class, 'modResource', '', array('id'));
 
             $c->where(["$f:IN" => $ids]);
+        } elseif (!empty($exclude)) {
+            $exclude = $this->cleanIds($exclude);
+            $f = $this->modx->getSelectColumns(modResource::class, 'modResource', '', ['id']);
+            $c->where(["{$f}:NOT IN" => explode(',', $exclude)]);
         }
 
         $c->where(['published:=' => 1]);


### PR DESCRIPTION
Currently the property `&exclude` is ignored if it is not used in combination with the property `&ids`.
With this PR,  `&exclude` can be used without using `&ids`.