### PR TITLE
Limit result with SQL if property 'sortBy' is used

### DIFF
--- a/core/components/simplesearch/src/Driver/SimpleSearchDriverBasic.php
+++ b/core/components/simplesearch/src/Driver/SimpleSearchDriverBasic.php
@@ -239,10 +239,31 @@ class SimpleSearchDriverBasic extends SimpleSearchDriver
         $total = $this->modx->getCount(modResource::class, $c);
 
         $c->query['distinct'] = 'DISTINCT';
-        if (!empty($scriptProperties['sortBy'])) {
+
+        $perPage = (int) $this->modx->getOption('perPage', $this->config, 10);
+        $offset = $this->modx->getOption('start', $this->config, 0);
+        $offsetIndex = $this->modx->getOption('offsetIndex', $this->config, 'simplesearch_offset');
+        if (isset($_REQUEST[$offsetIndex])) {
+            $offset = (int) $_REQUEST[$offsetIndex];
+        }
+
+        $sortBy = $this->modx->getOption('sortBy', $scriptProperties, '');
+        $maxCountPhpSort = (int) $this->modx->getOption('maxCountPhpSort', $scriptProperties, 0);
+        if (empty($sortBy) && $maxCountPhpSort && $total > $maxCountPhpSort){
+            // Too many results to sort in PHP -> Use limit in SQL-Query
+            $fallbackSortBy = $this->modx->getOption('fallbackSortBy', $scriptProperties, '');
+            if ($fallbackSortBy) {
+                $sortBy = $fallbackSortBy;
+            } else {
+                $sortBy = 'id';
+            }
+        }
+
+        if (!empty($sortBy)) {
+            // sort and limit resources with SQL
             $sortDir  = $this->modx->getOption('sortDir', $scriptProperties, 'DESC');
             $sortDirs = explode(',', $sortDir);
-            $sortBys  = explode(',', $scriptProperties['sortBy']);
+            $sortBys  = explode(',', $sortBy);
             $dir      = 'desc';
             for ($i = 0, $iMax = count($sortBys); $i < $iMax; $i++) {
                 if (isset($sortDirs[$i])) {
@@ -251,24 +272,19 @@ class SimpleSearchDriverBasic extends SimpleSearchDriver
 
                 $c->sortby('modResource.' . $sortBys[$i], strtoupper($dir));
             }
+            if ($perPage > 0) {
+                $c->limit($perPage, $offset);
+            }
         }
 
         $resources = $this->modx->getCollection(modResource::class, $c);
-        if (empty($scriptProperties['sortBy'])) {
+
+        if (empty($sortBy)) {
+            // sort and limit resources in PHP
             $resources = $this->sortResults($resources, $scriptProperties);
-        }
-
-        /* Set limit */
-        $perPage = (int) $this->modx->getOption('perPage', $this->config, 10);
-        if ($perPage > 0) {
-            $offset      = $this->modx->getOption('start', $this->config, 0);
-            $offsetIndex = $this->modx->getOption('offsetIndex', $this->config, 'simplesearch_offset');
-
-            if (isset($_REQUEST[$offsetIndex])) {
-                $offset = (int) $_REQUEST[$offsetIndex];
+            if ($perPage > 0) {
+                $resources = array_slice($resources, $offset, $perPage);
             }
-
-            $resources = array_slice($resources, $offset, $perPage);
         }
 
         $includeTVs = $this->modx->getOption('includeTVs', $scriptProperties, '');


### PR DESCRIPTION
The way the search is currently implemented can be very inefficient.
By default, all matching resources are returned by SQL and then `array_slice()` is used in PHP for the paging.
This makes sense, if the matching resources are sorted by relevance in PHP (which is the default), but is unnecessary if the `&sortBy` property is used (and the results are already sorted in SQL).

---

If "SimpleSearch" is used on a bigger site in combination with a commonly used word as the search term, the amount of matching resources can create a "memory limit error".
https://community.modx.com/t/diagnosing-simplesearch-memory-limit-error/5700

This PR adds a way to avoid this (while still allowing the use of the relevance sorting in PHP for smaller search results).

```
[[!SimpleSearch?
    ...
    &maxCountPhpSort=`200`
    &fallbackSortBy=`createdon`
]]
```
With a snippet tag like this, the relevance sorting in PHP is used, if the total amount of matching resources is less than 200.
For a larger amount of matching resources, the result is sorted and limited with SQL (using the value from the property `&fallbackSortBy` for the sorting).